### PR TITLE
correct base url for individual page country screenshot

### DIFF
--- a/src/PrivacyProtection/PrivacyProtection.jsx
+++ b/src/PrivacyProtection/PrivacyProtection.jsx
@@ -113,7 +113,7 @@ export default injectIntl(
       if (enabled && !bgImg && !show) {
         fetch(
           `${getBaseUrl(
-            path || '',
+            '',
           )}/cors-proxy/https://screenshot.eea.europa.eu/api/v1/retrieve_image_for_url?url=${
             data.url
           }&w=1920&waitfor=4000`,


### PR DESCRIPTION
The request url included "countries/{country}/{country}-basic-data/ which took to a bad request, and this fix gets rid of that additional path.