### PR TITLE
Increase wait time EEA Screenshooter when saving preview image

### DIFF
--- a/src/Widgets/MapsWidget.jsx
+++ b/src/Widgets/MapsWidget.jsx
@@ -216,7 +216,7 @@ export default function MapsWidget(props) {
           '',
         )}/cors-proxy/https://screenshot.eea.europa.eu/api/v1/retrieve_image_for_url?url=${encodeURIComponent(
           value.url,
-        )}&w=1920&h=1000&waitfor=4000`,
+        )}&w=1920&h=1000&waitfor=8000`,
       )
         .then((e) => e.blob())
         .then((myBlob) => {


### PR DESCRIPTION
After creating the script to save all the preview images of the existing content we saw that some of the Maps are not fully loaded when the screenshooter is taking the picture