### PR TITLE
fix: Remove async from preview_image middleware - refs #304013

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -65,11 +65,6 @@ msgstr "Voll"
 msgid "Left"
 msgstr "Links"
 
-#. Default: "Live image generated"
-#: PrivacyProtection/PrivacyProtection
-msgid "Live image generated"
-msgstr "Live-Bild generiert"
-
 #. Default: "Map height"
 #: Blocks/EmbedMaps/schema
 #: Blocks/Maps/schema
@@ -102,11 +97,6 @@ msgstr "Bitte geben Sie den Einbettungscode oder die URL für die ESRI-Webkarte 
 #: Blocks/Maps/Edit
 msgid "Right"
 msgstr "Rechts"
-
-#. Default: "Success"
-#: PrivacyProtection/PrivacyProtection
-msgid "Success"
-msgstr "Erfolgreich"
 
 #. Default: "Use screen height"
 #: Blocks/Maps/schema

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -65,11 +65,6 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#. Default: "Live image generated"
-#: PrivacyProtection/PrivacyProtection
-msgid "Live image generated"
-msgstr ""
-
 #. Default: "Map height"
 #: Blocks/EmbedMaps/schema
 #: Blocks/Maps/schema
@@ -101,11 +96,6 @@ msgstr ""
 #. Default: "Right"
 #: Blocks/Maps/Edit
 msgid "Right"
-msgstr ""
-
-#. Default: "Success"
-#: PrivacyProtection/PrivacyProtection
-msgid "Success"
 msgstr ""
 
 #. Default: "Use screen height"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -65,11 +65,6 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#. Default: "Live image generated"
-#: PrivacyProtection/PrivacyProtection
-msgid "Live image generated"
-msgstr ""
-
 #. Default: "Map height"
 #: Blocks/EmbedMaps/schema
 #: Blocks/Maps/schema
@@ -101,11 +96,6 @@ msgstr ""
 #. Default: "Right"
 #: Blocks/Maps/Edit
 msgid "Right"
-msgstr ""
-
-#. Default: "Success"
-#: PrivacyProtection/PrivacyProtection
-msgid "Success"
 msgstr ""
 
 #. Default: "Use screen height"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -65,11 +65,6 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#. Default: "Live image generated"
-#: PrivacyProtection/PrivacyProtection
-msgid "Live image generated"
-msgstr ""
-
 #. Default: "Map height"
 #: Blocks/EmbedMaps/schema
 #: Blocks/Maps/schema
@@ -101,11 +96,6 @@ msgstr ""
 #. Default: "Right"
 #: Blocks/Maps/Edit
 msgid "Right"
-msgstr ""
-
-#. Default: "Success"
-#: PrivacyProtection/PrivacyProtection
-msgid "Success"
 msgstr ""
 
 #. Default: "Use screen height"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-03-10T22:12:54.862Z\n"
+"POT-Creation-Date: 2026-06-23T18:26:04.153Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -67,11 +67,6 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#. Default: "Live image generated"
-#: PrivacyProtection/PrivacyProtection
-msgid "Live image generated"
-msgstr ""
-
 #. Default: "Map height"
 #: Blocks/EmbedMaps/schema
 #: Blocks/Maps/schema
@@ -103,11 +98,6 @@ msgstr ""
 #. Default: "Right"
 #: Blocks/Maps/Edit
 msgid "Right"
-msgstr ""
-
-#. Default: "Success"
-#: PrivacyProtection/PrivacyProtection
-msgid "Success"
 msgstr ""
 
 #. Default: "Use screen height"

--- a/src/Blocks/EmbedMaps/View.test.jsx
+++ b/src/Blocks/EmbedMaps/View.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-intl-redux';
 import config from '@plone/volto/registry';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
 import View from './View';
@@ -21,40 +22,42 @@ describe('EmbedMaps Block View', () => {
   it('renders a view embed map block component', () => {
     render(
       <Provider store={global.store}>
-        <View
-          id="my-map"
-          data={{
-            '@type': 'embed_maps',
-            with_notes: false,
-            with_sources: false,
-            with_more_info: true,
-            with_share: true,
-            with_enlarge: true,
-            url: '/path/to/map',
-            maps: {
-              '@id': '/path/to/map',
-              title: 'My map',
-              url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
-            },
-            dataprotection: {
-              enabled: false,
-            },
-            useVisibilitySensor: false,
-            parameters: {
-              '@id': '647e4a0f-d4a0-4b8a-9965-0a016f017ebd',
-              field: 'zoomtocountry',
-              value: 'RO',
-            },
-            height: '800',
-          }}
-          data_query={[
-            {
-              i: 'Country',
-              o: 'plone.app.querystring.operation.selection.is',
-              v: ['RO'],
-            },
-          ]}
-        />
+        <MemoryRouter>
+          <View
+            id="my-map"
+            data={{
+              '@type': 'embed_maps',
+              with_notes: false,
+              with_sources: false,
+              with_more_info: true,
+              with_share: true,
+              with_enlarge: true,
+              url: '/path/to/map',
+              maps: {
+                '@id': '/path/to/map',
+                title: 'My map',
+                url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
+              },
+              dataprotection: {
+                enabled: false,
+              },
+              useVisibilitySensor: false,
+              parameters: {
+                '@id': '647e4a0f-d4a0-4b8a-9965-0a016f017ebd',
+                field: 'zoomtocountry',
+                value: 'RO',
+              },
+              height: '800',
+            }}
+            data_query={[
+              {
+                i: 'Country',
+                o: 'plone.app.querystring.operation.selection.is',
+                v: ['RO'],
+              },
+            ]}
+          />
+        </MemoryRouter>
       </Provider>,
     );
     expect(screen.getByTitle('Embeded ESRI Maps')).toBeInTheDocument();
@@ -67,15 +70,17 @@ describe('EmbedMaps Block View', () => {
   it('renders an edit view embed map block component', () => {
     render(
       <Provider store={global.store}>
-        <View
-          id="my-map"
-          mode="edit"
-          data={{
-            '@type': 'embed_maps',
-            url: '',
-            maps: {},
-          }}
-        />
+        <MemoryRouter>
+          <View
+            id="my-map"
+            mode="edit"
+            data={{
+              '@type': 'embed_maps',
+              url: '',
+              maps: {},
+            }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
     expect(
@@ -86,15 +91,17 @@ describe('EmbedMaps Block View', () => {
   it('handles map error', () => {
     render(
       <Provider store={global.store}>
-        <View
-          id="my-map"
-          data={{
-            '@type': 'embed_maps',
-            maps: {
-              error: 'Error message',
-            },
-          }}
-        />
+        <MemoryRouter>
+          <View
+            id="my-map"
+            data={{
+              '@type': 'embed_maps',
+              maps: {
+                error: 'Error message',
+              },
+            }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
 
@@ -104,19 +111,21 @@ describe('EmbedMaps Block View', () => {
   it('handles share button click', () => {
     render(
       <Provider store={global.store}>
-        <View
-          id="my-map"
-          data={{
-            '@type': 'embed_maps',
-            with_share: true,
-            url: '/path/to/map',
-            maps: {
-              '@id': '/path/to/map',
-              title: 'My map',
-              url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
-            },
-          }}
-        />
+        <MemoryRouter>
+          <View
+            id="my-map"
+            data={{
+              '@type': 'embed_maps',
+              with_share: true,
+              url: '/path/to/map',
+              maps: {
+                '@id': '/path/to/map',
+                title: 'My map',
+                url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
+              },
+            }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
 

--- a/src/Blocks/Maps/Edit.test.jsx
+++ b/src/Blocks/Maps/Edit.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
 import config from '@plone/volto/registry';
 import '@testing-library/jest-dom';
 
@@ -38,20 +39,22 @@ describe('Test Maps Block editing', () => {
   it('renders the edit form with a map', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <Edit
-          data={data}
-          pathname="/news"
-          selected={false}
-          block="1234"
-          index={1}
-          onChangeBlock={() => {}}
-          onSelectBlock={() => {}}
-          onDeleteBlock={() => {}}
-          onFocusPreviousBlock={() => {}}
-          onFocusNextBlock={() => {}}
-          handleKeyDown={() => {}}
-          content={{}}
-        />
+        <MemoryRouter>
+          <Edit
+            data={data}
+            pathname="/news"
+            selected={false}
+            block="1234"
+            index={1}
+            onChangeBlock={() => {}}
+            onSelectBlock={() => {}}
+            onDeleteBlock={() => {}}
+            onFocusPreviousBlock={() => {}}
+            onFocusNextBlock={() => {}}
+            handleKeyDown={() => {}}
+            content={{}}
+          />
+        </MemoryRouter>
       </Provider>,
     );
     expect(screen.getByTitle('ESRI Maps Embedded Block')).toBeInTheDocument();
@@ -61,23 +64,25 @@ describe('Test Maps Block editing', () => {
   it('renders the edit form without a map', () => {
     render(
       <Provider store={global.store}>
-        <Edit
-          data={{
-            '@type': 'maps',
-            url: '',
-          }}
-          pathname="/news"
-          selected={true}
-          block="1234"
-          index={1}
-          onChangeBlock={() => {}}
-          onSelectBlock={() => {}}
-          onDeleteBlock={() => {}}
-          onFocusPreviousBlock={() => {}}
-          onFocusNextBlock={() => {}}
-          handleKeyDown={() => {}}
-          content={{}}
-        />
+        <MemoryRouter>
+          <Edit
+            data={{
+              '@type': 'maps',
+              url: '',
+            }}
+            pathname="/news"
+            selected={true}
+            block="1234"
+            index={1}
+            onChangeBlock={() => {}}
+            onSelectBlock={() => {}}
+            onDeleteBlock={() => {}}
+            onFocusPreviousBlock={() => {}}
+            onFocusNextBlock={() => {}}
+            handleKeyDown={() => {}}
+            content={{}}
+          />
+        </MemoryRouter>
       </Provider>,
     );
     expect(
@@ -90,22 +95,24 @@ describe('Test Maps Block editing', () => {
   it('handles URL input', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <Edit
-          data={{
-            '@type': 'maps',
-            url: '',
-          }}
-          pathname="/news"
-          selected={true}
-          block="1234"
-          index={1}
-          onChangeBlock={jest.fn()}
-          onSelectBlock={jest.fn()}
-          onDeleteBlock={jest.fn()}
-          onFocusPreviousBlock={jest.fn()}
-          onFocusNextBlock={jest.fn()}
-          handleKeyDown={jest.fn()}
-        />
+        <MemoryRouter>
+          <Edit
+            data={{
+              '@type': 'maps',
+              url: '',
+            }}
+            pathname="/news"
+            selected={true}
+            block="1234"
+            index={1}
+            onChangeBlock={jest.fn()}
+            onSelectBlock={jest.fn()}
+            onDeleteBlock={jest.fn()}
+            onFocusPreviousBlock={jest.fn()}
+            onFocusNextBlock={jest.fn()}
+            handleKeyDown={jest.fn()}
+          />
+        </MemoryRouter>
       </Provider>,
     );
 

--- a/src/Blocks/Maps/View.test.jsx
+++ b/src/Blocks/Maps/View.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
 import config from '@plone/volto/registry';
 import '@testing-library/jest-dom';
 
@@ -53,7 +54,9 @@ describe('Maps Block View', () => {
   it('test-1', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <View data={data} />
+        <MemoryRouter>
+          <View data={data} />
+        </MemoryRouter>
       </Provider>,
     );
 
@@ -67,12 +70,14 @@ describe('Maps Block View', () => {
   it('test-2', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <View
-          data={{
-            ...data,
-            height: '100vh',
-          }}
-        />
+        <MemoryRouter>
+          <View
+            data={{
+              ...data,
+              height: '100vh',
+            }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
 
@@ -85,17 +90,19 @@ describe('Maps Block View', () => {
   it('test-3', () => {
     const Component = (props) => (
       <Provider store={global.store}>
-        <View
-          data={{
-            ...data,
-            dataprotection: {
-              ...data.dataprotection,
-              enabled: true,
-            },
-            height: '100vh',
-            useVisibilitySensor: false,
-          }}
-        />
+        <MemoryRouter>
+          <View
+            data={{
+              ...data,
+              dataprotection: {
+                ...data.dataprotection,
+                enabled: true,
+              },
+              height: '100vh',
+              useVisibilitySensor: false,
+            }}
+          />
+        </MemoryRouter>
       </Provider>
     );
     const { container, rerender } = render(<Component />);

--- a/src/EmbedMap/EmbedMap.test.jsx
+++ b/src/EmbedMap/EmbedMap.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
 import config from '@plone/volto/registry';
 import '@testing-library/jest-dom';
 
@@ -28,22 +29,24 @@ describe('EmbedMap', () => {
   it('renders map component', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <EmbedMap
-          id="my-map"
-          data={{
-            with_notes: false,
-            with_sources: false,
-            with_more_info: true,
-            with_share: true,
-            with_enlarge: true,
-            url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
-            useVisibilitySensor: false,
-            parameters: {
-              Country: 'RO',
-              zoomtocountry: 'RO',
-            },
-          }}
-        />
+        <MemoryRouter>
+          <EmbedMap
+            id="my-map"
+            data={{
+              with_notes: false,
+              with_sources: false,
+              with_more_info: true,
+              with_share: true,
+              with_enlarge: true,
+              url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
+              useVisibilitySensor: false,
+              parameters: {
+                Country: 'RO',
+                zoomtocountry: 'RO',
+              },
+            }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
     expect(screen.getByTitle('Embeded ESRI Maps')).toBeInTheDocument();
@@ -59,24 +62,26 @@ describe('EmbedMap', () => {
   it('handles mobile view', () => {
     const { container } = render(
       <Provider store={global.store}>
-        <EmbedMap
-          id="my-map"
-          data={{
-            with_notes: false,
-            with_sources: false,
-            with_more_info: true,
-            with_share: true,
-            with_enlarge: true,
-            url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
-            useVisibilitySensor: false,
-            parameters: {
-              Country: 'RO',
-              zoomtocountry: 'RO',
-            },
-          }}
-          intl={{ formatMessage: (message) => message.defaultMessage }}
-          screen={{ width: 400 }}
-        />
+        <MemoryRouter>
+          <EmbedMap
+            id="my-map"
+            data={{
+              with_notes: false,
+              with_sources: false,
+              with_more_info: true,
+              with_share: true,
+              with_enlarge: true,
+              url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
+              useVisibilitySensor: false,
+              parameters: {
+                Country: 'RO',
+                zoomtocountry: 'RO',
+              },
+            }}
+            intl={{ formatMessage: (message) => message.defaultMessage }}
+            screen={{ width: 400 }}
+          />
+        </MemoryRouter>
       </Provider>,
     );
 

--- a/src/Views/MapView.test.jsx
+++ b/src/Views/MapView.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
 import config from '@plone/volto/registry';
 import '@testing-library/jest-dom';
 
@@ -40,20 +41,22 @@ config.blocks.blocksConfig = {
 test('renders map component', () => {
   const { container } = render(
     <Provider store={global.store}>
-      <MapView
-        content={{
-          maps: {
-            '@id': '/path/to/map',
-            with_notes: false,
-            with_sources: false,
-            with_more_info: true,
-            with_share: true,
-            with_enlarge: true,
-            url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
-            useVisibilitySensor: false,
-          },
-        }}
-      />
+      <MemoryRouter>
+        <MapView
+          content={{
+            maps: {
+              '@id': '/path/to/map',
+              with_notes: false,
+              with_sources: false,
+              with_more_info: true,
+              with_share: true,
+              with_enlarge: true,
+              url: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3027.7835278268726!2d14.38842915203974!3d40.634655679238854!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x133b994881d943cb%3A0x6ab93db57d3272f0!2sHotel+Mediterraneo+Sorrento!5e0!3m2!1sen!2ses!4v1550168740166',
+              useVisibilitySensor: false,
+            },
+          }}
+        />
+      </MemoryRouter>
     </Provider>,
   );
 

--- a/src/middlewares/preview_image.js
+++ b/src/middlewares/preview_image.js
@@ -27,7 +27,7 @@ const cleanAction = (action) => {
 };
 
 export const preview_image = (middlewares) => [
-  (store) => (next) => async (action) => {
+  (store) => (next) => (action) => {
     if (![CREATE_CONTENT, UPDATE_CONTENT].includes(action.type)) {
       return next(action);
     }


### PR DESCRIPTION
The `async` keyword on the `preview_image` Redux middleware created a new Promise wrapper around `next(action)`. When the `api` middleware's `actionPromise` rejected (e.g. 410 Gone on error pages), the `async` wrapper's Promise had no rejection handler, causing `unhandledrejection` events that were sent to Sentry.

## Root cause

The middleware chain is:

```
preview_image (async) → ... → api middleware
```

When a `GET_CONTENT` action fails (e.g. 410):

1. `api` middleware creates `actionPromise` (rejected), calls `.then(success, error)`, returns it
2. `async` `preview_image` does `return next(action)` — but because it's `async`, JS creates a **new Promise** that follows `actionPromise`
3. `api`'s `.then()` handles `actionPromise`'s rejection ✅
4. But the **new Promise** from the `async` wrapper has **no rejection handler** ❌
5. Browser fires `unhandledrejection` → Sentry captures it

## Fix

Remove the unnecessary `async` keyword. No `await` is used in the function, so `async` was not needed and caused this side effect.

## Testing

After this fix, navigating to 410 Gone / 404 Not Found / 401 Unauthorized pages no longer produces `Uncaught (in promise) Error: Gone/Not Found/Unauthorized` in the browser console or Sentry.

Related: eea/volto-eea-website-theme#385, eea/volto-sentry-rancher-config (already merged)